### PR TITLE
fix: use `Uint8List` instead of String for `PSKCredentials`

### DIFF
--- a/lib/src/psk_credentials.dart
+++ b/lib/src/psk_credentials.dart
@@ -3,14 +3,16 @@
 //
 // SPDX-License-Identifier: EPL-1.0 OR BSD-3-CLAUSE
 
+import 'dart:typed_data';
+
 /// Credentials used for PSK Cipher Suites consisting of an [identity]
 /// and a [preSharedKey].
 class PskCredentials {
   /// The identity used with the [preSharedKey].
-  String identity;
+  Uint8List identity;
 
   /// The actual pre-shared key.
-  String preSharedKey;
+  Uint8List preSharedKey;
 
   /// Constructor
   PskCredentials({required this.identity, required this.preSharedKey});

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -6,6 +6,7 @@
 import 'dart:ffi';
 import 'dart:ffi' as ffi;
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'ffi/generated_bindings.dart';
 import 'psk_credentials.dart';
@@ -65,9 +66,9 @@ typedef NativeEcdsaVerifyHandler = ffi.Int32 Function(
 /// As the format of the [identityHint] is not well-defined, this parameter
 /// can probably be ignored in most cases, when both the identity and the key
 /// are known in advance.
-typedef PskCallback = PskCredentials Function(String identityHint);
+typedef PskCallback = PskCredentials Function(Uint8List identityHint);
 
 /// Function signature for a callback function for generating a PSK identity
 /// hint for a peer, optionally based on its [address] and/or [port].
-typedef PskIdentityHintCallback = String Function(
+typedef PskIdentityHintCallback = Uint8List Function(
     InternetAddress address, int port);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
+  collection: ^1.16.0
   ffi: ^1.1.2
 
 dev_dependencies:


### PR DESCRIPTION
Previous versions of `dart_tinydtls` required the use of UTF-8 encoded `String`s for both Pre-Shared Keys and their associated identities. This prevented the use of the library in scenarios where generic byte sequences are used for the identity or the PSK.

This PR broadens the range of accepted input values by changing the type of both arguments to `Uint8List`, making the library usable for scenarios like ACE-OAuth.