### PR TITLE
feat: throw `DtlsException`s instead of `StateError`s on error

### DIFF
--- a/lib/dart_tinydtls.dart
+++ b/lib/dart_tinydtls.dart
@@ -64,6 +64,7 @@ import 'src/types.dart' show PskCallback;
 export 'src/client.dart' show DtlsClient;
 export 'src/dtls_connection.dart';
 export 'src/dtls_event.dart' show DtlsEvent;
+export 'src/dtls_exception.dart';
 export 'src/ecdsa_keys.dart' show EcdsaKeys, EcdsaCurve;
 export 'src/ffi/generated_bindings.dart' show TinyDTLS;
 export 'src/psk_credentials.dart';

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -14,6 +14,7 @@ import 'package:ffi/ffi.dart';
 
 import 'dtls_connection.dart';
 import 'dtls_event.dart';
+import 'dtls_exception.dart';
 import 'ecdsa_keys.dart';
 import 'ffi/generated_bindings.dart';
 import 'library.dart';
@@ -331,10 +332,8 @@ class DtlsClient {
 
     final result = _tinyDtls.dtls_connect(context, session);
 
-    if (result == 0) {
-      throw StateError("DTLS channel already exists!");
-    } else if (result < 0) {
-      throw StateError("An error occurred while trying to connect");
+    if (result < 0) {
+      throw DtlsException("An error occurred while trying to connect");
     }
 
     return connection._connectCompleter.future;
@@ -375,9 +374,7 @@ class DtlsClient {
     final result = _tinyDtls.dtls_write(context, session, buffer, data.length);
 
     if (result == -1) {
-      throw StateError("Error sending DTLS message");
-    } else if (result == 0) {
-      throw StateError("Not connected to DTLS peer");
+      throw DtlsException("Error sending DTLS message");
     }
 
     return result;
@@ -476,7 +473,7 @@ class DtlsClientConnection extends Stream<Datagram> implements DtlsConnection {
   @override
   int send(List<int> data) {
     if (!_connected) {
-      throw StateError("Sending failed: Not connected!");
+      throw DtlsException("Sending failed: Not connected!");
     }
     return _dtlsClient._send(data, _context, _session);
   }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -373,7 +373,7 @@ class DtlsClient {
     buffer.asTypedList(data.length).setAll(0, data);
     final result = _tinyDtls.dtls_write(context, session, buffer, data.length);
 
-    if (result == -1) {
+    if (result < 0) {
       throw DtlsException("Error sending DTLS message");
     }
 

--- a/lib/src/dtls_connection.dart
+++ b/lib/src/dtls_connection.dart
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: EPL-1.0 OR BSD-3-CLAUSE
 
 import 'dart:io';
+import 'dtls_exception.dart';
 
 /// Represents a DTLS connection to a peer.
 ///
@@ -15,7 +16,7 @@ abstract class DtlsConnection extends Stream<Datagram> {
 
   /// Sends [data] to the endpoint of this [DtlsConnection].
   ///
-  /// Returns the number of bytes written. A [StateError] is thrown if the
+  /// Returns the number of bytes written. A [DtlsException] is thrown if the
   /// client or server is not connected to the peer anymore.
   int send(List<int> data);
 

--- a/lib/src/dtls_exception.dart
+++ b/lib/src/dtls_exception.dart
@@ -1,0 +1,16 @@
+// Copyright 2022 The NAMIB Project Developers. All rights reserved.
+// See the README as well as the LICENSE file for more information.
+//
+// SPDX-License-Identifier: EPL-1.0 OR BSD-3-CLAUSE
+
+/// This [Exception] is thrown when an error occurs within dart_tinydtls.
+class DtlsException implements Exception {
+  /// Constructor.
+  DtlsException(this.message);
+
+  /// The error message of this [DtlsException].
+  final String message;
+
+  @override
+  String toString() => "DtlsException: $message";
+}

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -12,6 +12,7 @@ import 'package:ffi/ffi.dart';
 
 import 'dtls_connection.dart';
 import 'dtls_event.dart';
+import 'dtls_exception.dart';
 import 'ecdsa_keys.dart';
 import 'ffi/generated_bindings.dart';
 import 'library.dart';
@@ -298,9 +299,7 @@ class DtlsServer extends Stream<DtlsServerConnection> {
     final result = _tinyDtls.dtls_write(context, session, buffer, data.length);
 
     if (result == -1) {
-      throw StateError("Error sending DTLS message");
-    } else if (result == 0) {
-      throw StateError("Not connected to DTLS peer");
+      throw DtlsException("Error sending DTLS message");
     }
 
     return result;
@@ -392,7 +391,7 @@ class DtlsServerConnection extends Stream<Datagram> implements DtlsConnection {
   @override
   int send(List<int> data) {
     if (!_connected) {
-      throw StateError("Sending failed: Not connected!");
+      throw DtlsException("Sending failed: Not connected!");
     }
     return _server._send(data, _context, _session);
   }

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -298,7 +298,7 @@ class DtlsServer extends Stream<DtlsServerConnection> {
     buffer.asTypedList(data.length).setAll(0, data);
     final result = _tinyDtls.dtls_write(context, session, buffer, data.length);
 
-    if (result == -1) {
+    if (result < 0) {
       throw DtlsException("Error sending DTLS message");
     }
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
 
+import 'dtls_exception.dart';
 import 'ffi/generated_bindings.dart';
 import 'library.dart';
 
@@ -103,7 +104,7 @@ Pointer<session_t> createSession(
   malloc.free(addr);
 
   if (session.address == nullptr.address) {
-    throw StateError("Error occurred establishing DTLS session");
+    throw DtlsException("Error occurred establishing DTLS session");
   }
 
   return session;


### PR DESCRIPTION
Currently, there are a number of places within the library where unrecoverable `StateError`s are thrown. This is actually not necessary, and thrown an `Exception` is totally sufficient. Therefore, a new `DtlsException` class is added and used instead. At some places where the `throw` statement is removed, as the respective return value does not actually indicate an error.