### PR TITLE
fix!: don't throw `StateError`s for unknown alert parameters

### DIFF
--- a/lib/src/dtls_event.dart
+++ b/lib/src/dtls_event.dart
@@ -33,15 +33,7 @@ enum AlertLevel {
       HashMap.fromEntries(values.map((value) => MapEntry(value._code, value)));
 
   /// Creates an [AlertDescription] from a numeric [code].
-  static AlertLevel fromCode(int code) {
-    final alertlevel = _registry[code];
-
-    if (alertlevel == null) {
-      throw StateError("Encountered unknown DTLS Alert Level $code");
-    }
-
-    return alertlevel;
-  }
+  static AlertLevel? fromCode(int code) => _registry[code];
 
   @override
   String toString() => "Alert Level '$_stringValue'";
@@ -51,11 +43,6 @@ enum _DescriptionConstraints {
   unspecified,
   alwaysWarning,
   alwaysFatal;
-
-  bool disallowLevel(AlertLevel alertLevel) {
-    return (this == alwaysFatal && alertLevel != AlertLevel.fatal) ||
-        (this == alwaysWarning && alertLevel != AlertLevel.warning);
-  }
 }
 
 /// The description component of a [DtlsEvent].
@@ -318,15 +305,7 @@ enum AlertDescription {
       HashMap.fromEntries(values.map((value) => MapEntry(value._code, value)));
 
   /// Creates an [AlertDescription] from a numeric [code].
-  static AlertDescription fromCode(int code) {
-    final description = _registry[code];
-
-    if (description == null) {
-      throw StateError("Encountered unknown DTLS Alert Description");
-    }
-
-    return description;
-  }
+  static AlertDescription? fromCode(int code) => _registry[code];
 
   @override
   String toString() {
@@ -340,19 +319,13 @@ enum AlertDescription {
 /// Consists of an [alertLevel] and a [alertDescription].
 class DtlsEvent {
   /// The alert level of this alert.
-  final AlertLevel alertLevel;
+  final AlertLevel? alertLevel;
 
   /// The description of this alert.
-  final AlertDescription alertDescription;
+  final AlertDescription? alertDescription;
 
   /// Constructor.
-  DtlsEvent(this.alertLevel, this.alertDescription) {
-    if (alertDescription._constraints.disallowLevel(alertLevel)) {
-      throw StateError(
-          "Required ${AlertLevel.warning} for $alertDescription but got "
-          "$alertLevel");
-    }
-  }
+  DtlsEvent(this.alertLevel, this.alertDescription);
 
   /// Constructor.
   factory DtlsEvent.fromCodes(int level, int code) {
@@ -371,6 +344,11 @@ class DtlsEvent {
       alertDescription == AlertDescription.closeNotify;
 
   @override
-  String toString() =>
-      "DtlsEvent with $alertLevel and description '$alertDescription'.";
+  String toString() {
+    final levelString = alertLevel?.toString() ?? "unknown Alert Level";
+    final descriptionString =
+        alertDescription?.toString() ?? "unknown Description";
+
+    return "DtlsEvent with $levelString and description '$descriptionString'.";
+  }
 }

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -202,7 +202,7 @@ class DtlsServer extends Stream<DtlsServerConnection> {
   ///
   /// The server will either use the pairs of Identities and Pre-Shared Keys
   /// provided by the [pskKeyStoreCallback] or a set of [EcdsaKeys] to establish
-  /// connections with peers. If no credentials are provided, a [StateError]
+  /// connections with peers. If no credentials are provided, an [ArgumentError]
   /// will be thrown.
   ///
   /// Uses a [RawDatagramSocket] internally and passes the [host], [port],


### PR DESCRIPTION
#3 introduced the throwing of `StateError`s in cases where the underlying tinydtls instance passes "illegal" alert combinations to `dart_tinydtls`. As it seems as if there is no check within tinydtls that only "legal" alerts are passed to the event callback, this has been a potential source for critical application errors when a peer sends alerts which are not standard-compliant.

With this PR, the respective fields in the `Alert` class are simply set to `null`, mitigating the threat of crashing applications.

While this technically constitutes a breaking API change, I will include this in a 3.1.0 release as it is a very specific part of the API.